### PR TITLE
fix: correct GitHub URL

### DIFF
--- a/apps/www/components/docs/nav.tsx
+++ b/apps/www/components/docs/nav.tsx
@@ -93,7 +93,7 @@ export const Nav = () => {
 
           <div className="flex items-center gap-1 max-md:hidden">
             <a
-              href="https://x.com/animate_ui"
+              href="https://github.com/imskyleen/animate-ui"
               rel="noreferrer noopener"
               target="_blank"
               className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors duration-100 disabled:pointer-events-none disabled:opacity-50 hover:bg-fd-accent hover:text-fd-accent-foreground size-8 [&_svg]:size-5 text-fd-muted-foreground"


### PR DESCRIPTION
Fix GitHub URL - earlier it was pointing to X from the GitHub button. Now updated to the correct link.
